### PR TITLE
Remove `max_files` configuration option

### DIFF
--- a/src/Fieldtypes/PinPointImage.php
+++ b/src/Fieldtypes/PinPointImage.php
@@ -79,13 +79,6 @@ class PinPointImage extends Fieldtype
                 'default' => true,
                 'width' => 50,
             ],
-            'max_files' => [
-                'display' => __('Max Files'),
-                'instructions' => __('statamic::fieldtypes.assets.config.max_files'),
-                'min' => 1,
-                'type' => 'integer',
-                'width' => 50,
-            ],
         ];
     }
 


### PR DESCRIPTION
I had configured this when playing around with the addon but found it only seemed to actually work with a single file selected. Might be worth removing the option if there's no support for it.